### PR TITLE
fix missing fontPackage in serialzation

### DIFF
--- a/lib/Serialization/iconDataSerialization.dart
+++ b/lib/Serialization/iconDataSerialization.dart
@@ -11,6 +11,7 @@ Map<String, dynamic> iconDataToMap(IconData iconData) {
   Map<String, dynamic> result = new Map<String, dynamic>.from({
     'codePoint': iconData.codePoint,
     'fontFamily': iconData.fontFamily,
+    'fontPackage': iconData.fontPackage,
     'matchTextDirection': iconData.matchTextDirection
   });
   return result;
@@ -20,5 +21,6 @@ Map<String, dynamic> iconDataToMap(IconData iconData) {
 IconData mapToIconData(Map<String, dynamic> map) {
   return new IconData(map['codePoint'],
       fontFamily: map['fontFamily'],
+      fontPackage: map['fontPackage'],
       matchTextDirection: map['matchTextDirection']);
 }


### PR DESCRIPTION
Hi Ahmadre, thank you for your IconPicker.

I use it in my flutter project and find out this bug that the serialization logic is missing 'fontPackage' param, making not possible to deserialize correctly for icondata other than official Flutter Icon.