### PR TITLE
Fixed "Error: Getter not found: 'adobe'"

### DIFF
--- a/lib/IconPicker/Packs/FontAwesome.dart
+++ b/lib/IconPicker/Packs/FontAwesome.dart
@@ -13,7 +13,6 @@ const Map<String, IconData> fontAwesomeIcons = {
   'solidAddressCard': FontAwesomeIcons.solidAddressCard,
   'adjust': FontAwesomeIcons.adjust,
   'adn': FontAwesomeIcons.adn,
-  'adobe': FontAwesomeIcons.adobe,
   'adversal': FontAwesomeIcons.adversal,
   'affiliatetheme': FontAwesomeIcons.affiliatetheme,
   'airFreshener': FontAwesomeIcons.airFreshener,


### PR DESCRIPTION
Hello,

I have Flutter in version 1.22.0 and flutter_iconpicker in 2.1.5.
While I want to build my project I get an error:

```
Launching lib\main.dart on Android SDK built for x86 64 in debug mode...
Running Gradle task 'assembleDebug'...
/D:/flutter/.pub-cache/hosted/pub.dartlang.org/flutter_iconpicker-2.1.5/lib/IconPicker/Packs/FontAwesome.dart:16:29: Error: Getter not found: 'adobe'.
  'adobe': FontAwesomeIcons.adobe,
                            ^^^^^


FAILURE: Build failed with an exception.

* Where:
Script 'D:\flutter\packages\flutter_tools\gradle\flutter.gradle' line: 904

* What went wrong:
Execution failed for task ':app:compileFlutterBuildDebug'.
> Process 'command 'D:\flutter\bin\flutter.bat'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 11s
Exception: Gradle task assembleDebug failed with exit code 1
```

It seems as adobe icon was removed in some version.