### PR TITLE
fix: Hive only needed for example

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.3
   font_awesome_flutter: ^9.0.0
-  hive: ^2.0.4
   provider: ^5.0.0
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.3
   font_awesome_flutter: ^9.0.0
-  provider: ^5.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Heyo @Ahmadre, nice new update.

Maybe Hive should only be mentioned for package, so others don't have to download the dependency when installing the package.