### PR TITLE
Remove tripadvisor font

### DIFF
--- a/lib/IconPicker/Packs/FontAwesome.dart
+++ b/lib/IconPicker/Packs/FontAwesome.dart
@@ -1404,7 +1404,6 @@ Map<String, IconData> fontAwesomeIcons = {
   'trashRestoreAlt': FontAwesomeIcons.trashRestoreAlt,
   'tree': FontAwesomeIcons.tree,
   'trello': FontAwesomeIcons.trello,
-  'tripadvisor': FontAwesomeIcons.tripadvisor,
   'trophy': FontAwesomeIcons.trophy,
   'truck': FontAwesomeIcons.truck,
   'truckLoading': FontAwesomeIcons.truckLoading,


### PR DESCRIPTION
Response to issue #30 
It got removed in the `font_awesome_flutter` package in this commit https://github.com/fluttercommunity/font_awesome_flutter/commit/32a780255717987fcdbb190ab281c25c3f00f3ab#diff-345938ec3543207b10539458bf2a1ee98d0227980d6b0c9b2ae891e38f1c12a3.
