### PR TITLE
docs: update link to icon_pack file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ dart run flutter_iconpicker:generate_packs --packs <material,cupertino,..>
 
 > Replace `<material,cupertino,..>` with the IconPack names you want! E.g. `--packs material,cupertino` (comma separated!)
 
-For the complete list of available pack names see: [Available IconPacks](lib/Models/IconPack.dart) (only those with path!)
+For the complete list of available pack names see: [Available IconPacks](lib/Models/icon_pack.dart) (only those with path!)
 
 For more see:
 


### PR DESCRIPTION
Hi @Ahmadre ,
Reading the `FlutterIconPicker` docs I realized the link that leads to the `IconPack` enum was broken, so I decided to make a small contribution by opening this PR.