### PR TITLE
[Fix]: mutually exclusive icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.6.3] - 07.09.2024
+
+* 🐛 Fix mutually exclusive icons while searching
+  * Thanks to [programotuojes](https://github.com/programotuojes) for the hint in [#80](https://github.com/Ahmadre/FlutterIconPicker/issues/80)
+
 ## [3.6.2] - 03.09.2024
 
 * 🐛 Fix typo in `Cupertino.dart` icons

--- a/lib/IconPicker/search_bar.dart
+++ b/lib/IconPicker/search_bar.dart
@@ -52,7 +52,7 @@ class _FIPSearchBarState extends State<FIPSearchBar> {
           .forEach((String key, IconPickerIcon val) {
         if (searchComparator.call(searchValue,
             IconPickerIcon(name: key, data: val.data, pack: pack))) {
-          searchResult.putIfAbsent(key, () => val);
+          searchResult[key] = val;
         }
       });
     }
@@ -61,7 +61,7 @@ class _FIPSearchBarState extends State<FIPSearchBar> {
       widget.customIconPack!.forEach((String key, IconPickerIcon val) {
         if (searchComparator.call(searchValue,
             IconPickerIcon(name: key, data: val.data, pack: IconPack.custom))) {
-          searchResult.putIfAbsent(key, () => val);
+          searchResult[key] = val;
         }
       });
     }

--- a/lib/IconPicker/search_bar.dart
+++ b/lib/IconPicker/search_bar.dart
@@ -44,7 +44,7 @@ class _FIPSearchBarState extends State<FIPSearchBar> {
   late final searchComparator =
       widget.searchComparator ?? _defaultSearchComparator;
 
-  _search(String searchValue) {
+  void _search(String searchValue) {
     Map<String, IconPickerIcon> searchResult = <String, IconPickerIcon>{};
 
     for (var pack in widget.iconPack!) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_iconpicker
 description: A Dialog for picking Icons in Flutter and use them anywhere. Can be
   used as a default Dialog or as a Adaptive Dialog.
-version: 3.6.2
+version: 3.6.3
 homepage: https://github.com/Ahmadre
 repository: https://github.com/Ahmadre/FlutterIconPicker
 


### PR DESCRIPTION
## Related Issues

- #80 

## Description

This Fix resolves the issue that icons with the same key name can be searched while key exists in multiple IconPack's.

- [x] Fix
- [x] Bump Version
- [x] Changelog entry