### PR TITLE
Feat/83 iconbuilder widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [4.0.0] - 07.09.2024
 
-* 💡 Add `iconBuilder` `WidgetBuilder` to create your own custom widgets for your displayed icons
+* 💡 Add `iconBuilder`: `IconWidgetBuilder` to create your own custom widgets for your displayed icons
 
 ## [3.6.6] - 07.09.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.0] - 07.09.2024
+
+* 💡 Add `iconBuilder` `WidgetBuilder` to create your own custom widgets for your displayed icons
+
 ## [3.6.6] - 07.09.2024
 
 * 🐛 [Hotfix]: Fix mutually exclusive icons while searching (flatten results)

--- a/lib/IconPicker/icon_picker.dart
+++ b/lib/IconPicker/icon_picker.dart
@@ -158,8 +158,12 @@ class _FIPIconPickerState extends State<FIPIconPicker> {
                             widget.iconController.selectedIcon! == item.value;
 
                         if (controller.iconBuilder != null) {
-                          return controller.iconBuilder!(context, item.value,
-                              isSelected, controller.onTapIcon);
+                          return controller.iconBuilder!(
+                            context,
+                            item.value,
+                            isSelected,
+                            controller.onTapIcon,
+                          );
                         }
 
                         final selectedIconColor =

--- a/lib/IconPicker/icon_picker.dart
+++ b/lib/IconPicker/icon_picker.dart
@@ -151,11 +151,15 @@ class _FIPIconPickerState extends State<FIPIconPicker> {
                       ),
                       itemBuilder: (context, index) {
                         final MapEntry<String, IconPickerIcon> item =
-                            controller.entries.elementAt(index);
+                            controller.entries.elementAt(index);                        
 
-                        final isSelectedIcon = widget
+                        final isSelected = widget
                                 .iconController.isSelectedIconAvailable &&
                             widget.iconController.selectedIcon! == item.value;
+
+                        if (controller.iconBuilder != null) {
+                          return controller.iconBuilder!(context, item.value, isSelected);
+                        }
 
                         final selectedIconColor =
                             widget.selectedIconBackgroundColor ??
@@ -166,7 +170,7 @@ class _FIPIconPickerState extends State<FIPIconPicker> {
                         return ClipRRect(
                           borderRadius: BorderRadius.circular(8),
                           child: Container(
-                            color: isSelectedIcon ? selectedIconColor : null,
+                            color: isSelected ? selectedIconColor : null,
                             child: GestureDetector(
                               onTap: () => controller.onTapIcon(
                                 item.value,

--- a/lib/IconPicker/icon_picker.dart
+++ b/lib/IconPicker/icon_picker.dart
@@ -151,14 +151,15 @@ class _FIPIconPickerState extends State<FIPIconPicker> {
                       ),
                       itemBuilder: (context, index) {
                         final MapEntry<String, IconPickerIcon> item =
-                            controller.entries.elementAt(index);                        
+                            controller.entries.elementAt(index);
 
                         final isSelected = widget
                                 .iconController.isSelectedIconAvailable &&
                             widget.iconController.selectedIcon! == item.value;
 
                         if (controller.iconBuilder != null) {
-                          return controller.iconBuilder!(context, item.value, isSelected);
+                          return controller.iconBuilder!(context, item.value,
+                              isSelected, controller.onTapIcon);
                         }
 
                         final selectedIconColor =
@@ -174,7 +175,7 @@ class _FIPIconPickerState extends State<FIPIconPicker> {
                             child: GestureDetector(
                               onTap: () => controller.onTapIcon(
                                 item.value,
-                                externalInvocation: () =>
+                                onSelected: () =>
                                     Navigator.pop(context, item.value),
                               ),
                               child: widget.showTooltips!

--- a/lib/IconPicker/multiple_icon_picker.dart
+++ b/lib/IconPicker/multiple_icon_picker.dart
@@ -157,8 +157,12 @@ class FIPMultipleIconPickerState extends State<FIPMultipleIconPicker> {
                             .contains(item.value);
 
                         if (controller.iconBuilder != null) {
-                          return controller.iconBuilder!(context, item.value,
-                              isSelected, controller.onTapIcon);
+                          return controller.iconBuilder!(
+                            context,
+                            item.value,
+                            isSelected,
+                            controller.onTapIcon,
+                          );
                         }
 
                         final selectedIconColor =

--- a/lib/IconPicker/multiple_icon_picker.dart
+++ b/lib/IconPicker/multiple_icon_picker.dart
@@ -156,6 +156,10 @@ class FIPMultipleIconPickerState extends State<FIPMultipleIconPicker> {
                         final isSelected = widget.iconController.selectedIcons
                             .contains(item.value);
 
+                        if (controller.iconBuilder != null) {
+                          return controller.iconBuilder!(context, item.value, isSelected);
+                        }
+
                         final selectedIconColor =
                             widget.selectedIconBackgroundColor ??
                                 (Theme.of(context).brightness == Brightness.dark

--- a/lib/IconPicker/multiple_icon_picker.dart
+++ b/lib/IconPicker/multiple_icon_picker.dart
@@ -157,7 +157,8 @@ class FIPMultipleIconPickerState extends State<FIPMultipleIconPicker> {
                             .contains(item.value);
 
                         if (controller.iconBuilder != null) {
-                          return controller.iconBuilder!(context, item.value, isSelected, controller.onTapIcon);
+                          return controller.iconBuilder!(context, item.value,
+                              isSelected, controller.onTapIcon);
                         }
 
                         final selectedIconColor =

--- a/lib/IconPicker/multiple_icon_picker.dart
+++ b/lib/IconPicker/multiple_icon_picker.dart
@@ -157,7 +157,7 @@ class FIPMultipleIconPickerState extends State<FIPMultipleIconPicker> {
                             .contains(item.value);
 
                         if (controller.iconBuilder != null) {
-                          return controller.iconBuilder!(context, item.value, isSelected);
+                          return controller.iconBuilder!(context, item.value, isSelected, controller.onTapIcon);
                         }
 
                         final selectedIconColor =

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
+typedef IconWidgetBuilder = Widget Function(BuildContext context, IconPickerIcon icon, bool isSelected);
+
 sealed class IconPickerConfiguration<T> {
   const IconPickerConfiguration({
+    this.iconBuilder,
     this.preSelected,
     this.shouldScrollToSelectedIcon = true,
     this.selectedIconBackgroundColor,
@@ -32,6 +35,8 @@ sealed class IconPickerConfiguration<T> {
     this.iconPackModes = const <IconPack>[IconPack.material],
     this.customIconPack,
   });
+
+  final IconWidgetBuilder? iconBuilder;
 
   /// Pre-selected icon before opening the icon picker
   /// If non-null the icon picker highlights and scrolls to the selected icon
@@ -156,6 +161,7 @@ sealed class IconPickerConfiguration<T> {
   final Map<String, IconPickerIcon>? customIconPack;
 
   IconPickerConfiguration copyWith({
+    IconWidgetBuilder? iconBuilder,
     T? preSelected,
     bool? shouldScrollToSelectedIcon,
     Color? selectedIconsBackgroundColor,
@@ -186,6 +192,7 @@ sealed class IconPickerConfiguration<T> {
 class SinglePickerConfiguration
     extends IconPickerConfiguration<IconPickerIcon> {
   const SinglePickerConfiguration({
+    super.iconBuilder,
     super.preSelected,
     super.shouldScrollToSelectedIcon = true,
     super.selectedIconBackgroundColor,
@@ -216,6 +223,7 @@ class SinglePickerConfiguration
 
   @override
   SinglePickerConfiguration copyWith({
+    IconWidgetBuilder? iconBuilder,
     IconPickerIcon? preSelected,
     bool? shouldScrollToSelectedIcon,
     Color? selectedIconsBackgroundColor,
@@ -241,6 +249,7 @@ class SinglePickerConfiguration
     Map<String, IconPickerIcon>? customIconPack,
   }) =>
       SinglePickerConfiguration(
+        iconBuilder: iconBuilder ?? super.iconBuilder,
         preSelected: preSelected ?? super.preSelected,
         shouldScrollToSelectedIcon:
             shouldScrollToSelectedIcon ?? super.shouldScrollToSelectedIcon,
@@ -272,6 +281,7 @@ class SinglePickerConfiguration
 class MultiplePickerConfiguration
     extends IconPickerConfiguration<List<IconPickerIcon>> {
   const MultiplePickerConfiguration({
+    super.iconBuilder,
     super.preSelected,
     super.shouldScrollToSelectedIcon = true,
     super.selectedIconBackgroundColor,
@@ -302,6 +312,7 @@ class MultiplePickerConfiguration
 
   @override
   MultiplePickerConfiguration copyWith({
+    IconWidgetBuilder? iconBuilder,
     List<IconPickerIcon>? preSelected,
     bool? shouldScrollToSelectedIcon,
     Color? selectedIconsBackgroundColor,
@@ -327,6 +338,7 @@ class MultiplePickerConfiguration
     Map<String, IconPickerIcon>? customIconPack,
   }) =>
       MultiplePickerConfiguration(
+        iconBuilder: iconBuilder ?? super.iconBuilder,
         preSelected: preSelected ?? super.preSelected,
         shouldScrollToSelectedIcon:
             shouldScrollToSelectedIcon ?? super.shouldScrollToSelectedIcon,

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -3,7 +3,11 @@ import 'package:flutter/material.dart';
 import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
-typedef IconWidgetBuilder = Widget Function(BuildContext context, IconPickerIcon icon, bool isSelected, void Function(IconPickerIcon, {VoidCallback? onSelected}) onTap);
+typedef IconWidgetBuilder = Widget Function(
+    BuildContext context,
+    IconPickerIcon icon,
+    bool isSelected,
+    void Function(IconPickerIcon, {VoidCallback? onSelected}) onTap);
 
 sealed class IconPickerConfiguration<T> {
   const IconPickerConfiguration({

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
-typedef IconWidgetBuilder = Widget Function(BuildContext context, IconPickerIcon icon, bool isSelected);
+typedef IconWidgetBuilder = Widget Function(BuildContext context, IconPickerIcon icon, bool isSelected, void Function(IconPickerIcon, {VoidCallback? onSelected}) onTap);
 
 sealed class IconPickerConfiguration<T> {
   const IconPickerConfiguration({

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -4,10 +4,11 @@ import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
 typedef IconWidgetBuilder = Widget Function(
-    BuildContext context,
-    IconPickerIcon icon,
-    bool isSelected,
-    void Function(IconPickerIcon, {VoidCallback? onSelected}) onTap);
+  BuildContext context,
+  IconPickerIcon icon,
+  bool isSelected,
+  void Function(IconPickerIcon, {VoidCallback? onSelected}) onTap,
+);
 
 sealed class IconPickerConfiguration<T> {
   const IconPickerConfiguration({

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -3,6 +3,15 @@ import 'package:flutter/material.dart';
 import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
+/// The IconWidgetBuilder is a function that builds a widget for the IconPicker
+/// 
+/// [context] The current BuildContext
+/// 
+/// [icon] The IconPickerIcon to build the widget for
+/// 
+/// [isSelected] If the icon is selected
+/// 
+/// [onTap] The function to call when the icon is tapped
 typedef IconWidgetBuilder = Widget Function(
   BuildContext context,
   IconPickerIcon icon,
@@ -41,6 +50,7 @@ sealed class IconPickerConfiguration<T> {
     this.customIconPack,
   });
 
+  /// The IconWidgetBuilder is a function that builds a widget for the IconPicker
   final IconWidgetBuilder? iconBuilder;
 
   /// Pre-selected icon before opening the icon picker

--- a/lib/Models/configuration.dart
+++ b/lib/Models/configuration.dart
@@ -4,13 +4,13 @@ import 'icon_pack.dart';
 import 'icon_picker_icon.dart';
 
 /// The IconWidgetBuilder is a function that builds a widget for the IconPicker
-/// 
+///
 /// [context] The current BuildContext
-/// 
+///
 /// [icon] The IconPickerIcon to build the widget for
-/// 
+///
 /// [isSelected] If the icon is selected
-/// 
+///
 /// [onTap] The function to call when the icon is tapped
 typedef IconWidgetBuilder = Widget Function(
   BuildContext context,

--- a/lib/controllers/icon_controller.dart
+++ b/lib/controllers/icon_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_iconpicker/Models/configuration.dart';
 import 'package:flutter_iconpicker/extensions/list_extensions.dart';
 
 import '../Models/icon_picker_icon.dart';
@@ -7,18 +8,22 @@ class FIPIconController with ChangeNotifier {
   FIPIconController({
     required bool shouldScrollToSelectedIcon,
     IconPickerIcon? selectedIcon,
+    IconWidgetBuilder? iconBuilder,
   })  : _selectedIcon = selectedIcon,
         _shouldScrollToSelectedIcon = shouldScrollToSelectedIcon,
-        _isMultiple = false;
+        _isMultiple = false,
+        _iconBuilder = iconBuilder;
 
   FIPIconController.multiple({
     required bool shouldScrollToSelectedIcon,
     List<IconPickerIcon> selectedIcons = const [],
+    IconWidgetBuilder? iconBuilder,
   })  : _selectedIcon =
             selectedIcons.isNotNullOrEmpty ? selectedIcons.first : null,
         _selectedIcons = selectedIcons,
         _shouldScrollToSelectedIcon = shouldScrollToSelectedIcon,
-        _isMultiple = true;
+        _isMultiple = true,
+        _iconBuilder = iconBuilder;
 
   final bool _isMultiple;
 
@@ -27,6 +32,10 @@ class FIPIconController with ChangeNotifier {
   final bool _shouldScrollToSelectedIcon;
 
   bool get shouldScrollToSelectedIcon => _shouldScrollToSelectedIcon;
+
+  IconWidgetBuilder? _iconBuilder;
+
+  IconWidgetBuilder? get iconBuilder => _iconBuilder;
 
   IconPickerIcon? _selectedIcon;
 

--- a/lib/controllers/icon_controller.dart
+++ b/lib/controllers/icon_controller.dart
@@ -55,9 +55,9 @@ class FIPIconController with ChangeNotifier {
     notifyListeners();
   }
 
-  void onTapIcon(IconPickerIcon val, {VoidCallback? externalInvocation}) {
+  void onTapIcon(IconPickerIcon val, {VoidCallback? onSelected}) {
     if (!_isMultiple) {
-      externalInvocation?.call();
+      onSelected?.call();
     } else {
       toggleSelectedIcon(val);
     }

--- a/lib/flutter_iconpicker.dart
+++ b/lib/flutter_iconpicker.dart
@@ -46,6 +46,7 @@ Future<IconPickerIcon?> showIconPicker(
   final controller = FIPIconController(
     selectedIcon: configuration.preSelected,
     shouldScrollToSelectedIcon: configuration.shouldScrollToSelectedIcon,
+    iconBuilder: configuration.iconBuilder,
   );
 
   if (configuration.adaptiveDialog) {
@@ -182,6 +183,7 @@ Future<List<IconPickerIcon>?> showMultipleIconPicker(
   final controller = FIPIconController.multiple(
     selectedIcons: configuration.preSelected ?? [],
     shouldScrollToSelectedIcon: configuration.shouldScrollToSelectedIcon,
+    iconBuilder: configuration.iconBuilder,
   );
 
   if (configuration.adaptiveDialog) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_iconpicker
 description: A Dialog for picking Icons in Flutter and use them anywhere. Can be
   used as a default Dialog or as a Adaptive Dialog.
-version: 3.6.6
+version: 4.0.0
 homepage: https://github.com/Ahmadre
 repository: https://github.com/Ahmadre/FlutterIconPicker
 


### PR DESCRIPTION
## Related Issues

- #83 

## Description

Provides the developer to create it's own custom icon with custom tap logic.

`iconBuilder` provides:

- context (`BuildContext`)
- icon (`IconPickerIcon`)
- isSelected (`bool`)
- onTap (`void Function(IconPickerIcon, {VoidCallback? onSelected})`)

## Screenshots 

**SinglePicker:**

```dart
iconBuilder: (context, icon, isSelected, onTap) => InkWell(
  onTap: () => onTap(
    icon,
    onSelected: () => Navigator.of(context).pop(icon),
  ),
  child: Container(
    color: isSelected ? Colors.blue : Colors.white54,
    child: Tooltip(
      message: '${icon.name} (${icon.pack.name})',
      child: Icon(icon.data),
    ),
  ),
),
```

<img width="500" alt="image" src="https://github.com/user-attachments/assets/786fcbee-df4b-41ed-921c-93a1e0049239">

**MultiplePicker:**

```dart
iconBuilder: (context, icon, isSelected, onTap) => InkWell(
  onTap: () => onTap(icon),
  child: Container(
    color: isSelected ? Colors.blue : Colors.white54,
    child: Tooltip(
      message: '${icon.name} (${icon.pack.name})',
      child: Icon(icon.data),
    ),
  ),
),
```

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5bfb1afc-2306-4660-b59d-ebfccb8ec04e">

## Warning

This change provides the user to do his own logic with onTap in Single and Multiple Pickers! So you as the developer are responsible for handling onTap!

Also parameters like: `showTooltips` obviously has not effect if you create your own icon.